### PR TITLE
Optional and empty services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: groovy
 jdk:
-- oraclejdk8
+- openjdk8
 sudo: false
 branches:
   only:

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
    // compile 'org.grails.grails-plugin-rest:2.3.0.M2'
     compile 'org.codehaus.groovy:groovy-ant:2.0.0'
 
-    compile "org.grails.plugins:ala-bootstrap3:3.0.6"
+    compile "org.grails.plugins:ala-bootstrap3:3.2.0"
     compile "org.grails.plugins:grails-google-visualization:2.0"
     compile "org.grails.plugins:ala-admin-plugin:2.0"
     runtime "org.grails.plugins:ala-auth:3.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
    // compile 'org.grails.grails-plugin-rest:2.3.0.M2'
     compile 'org.codehaus.groovy:groovy-ant:2.0.0'
 
-    compile "org.grails.plugins:ala-bootstrap3:3.2.0"
+    compile "org.grails.plugins:ala-bootstrap3:3.2.3"
     compile "org.grails.plugins:grails-google-visualization:2.0"
     compile "org.grails.plugins:ala-admin-plugin:2.0"
     runtime "org.grails.plugins:ala-auth:3.0.1"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -174,3 +174,6 @@ dashboard:
 csv:
   temp:
     dir: "/data/dashboard/csv/"
+
+useCitizenScienceService: true
+useVolunteerService: true

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -179,3 +179,4 @@ useCitizenScienceService: true
 useVolunteerService: true
 useBarcodeOfLifeService: true
 useNationalSpeciesListsService: true
+useBHLService: true

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -177,3 +177,5 @@ csv:
 
 useCitizenScienceService: true
 useVolunteerService: true
+useBarcodeOfLifeService: true
+useNationalSpeciesListsService: true

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -133,17 +133,17 @@ environments:
                 appServerName: "https://auth.ala.org.au"
 
 biocache:
-  baseURL: "https://biocache.ala.org.au"
+  baseURL: "https://biocache-ws.ala.org.au/ws"
 
 ala:
   baseURL: "https://www.ala.org.au"
 
 bie:
-  baseURL: "https://bie.ala.org.au"
+  baseURL: "https://bie-ws.ala.org.au/ws"
   searchPath: "/search"
 
 spatial:
-  baseURL: "http://spatial.ala.org.au"
+  baseURL: "http://spatial.ala.org.au/ws"
 
 logger:
   baseURL: "https://logger.ala.org.au"

--- a/grails-app/controllers/au/org/ala/dashboard/DashboardController.groovy
+++ b/grails-app/controllers/au/org/ala/dashboard/DashboardController.groovy
@@ -30,31 +30,52 @@ class DashboardController {
     }
 
     def collectionPanel = {
-        render view: 'panels/collectionPanel', model: [collections: metadataService.getCollectionsByCategory()]
+        if (metadataService.getCollectionsByCategory())
+            render view: 'panels/collectionPanel', model: [collections: metadataService.getCollectionsByCategory()]
+        else
+            render view: 'panels/empty'
     }
 
     def recordsPanel = {
-        render view: 'panels/recordsPanel', model: [totalRecords: metadataService.getTotalAndDuplicates()]
+        if (metadataService.getTotalAndDuplicates())
+            render view: 'panels/recordsPanel', model: [totalRecords: metadataService.getTotalAndDuplicates()]
+        else
+            render view: 'panels/empty'
     }
 
     def datasetsPanel = {
-        render view: 'panels/datasetsPanel', model: [datasets: metadataService.getDatasets()]
+        if (metadataService.getDatasets())
+            render view: 'panels/datasetsPanel', model: [datasets: metadataService.getDatasets()]
+        else
+            render view: 'panels/empty'
     }
 
     def basisRecordsPanel = {
-        render view: 'panels/basisRecordsPanel', model: [basisOfRecord: metadataService.getBasisOfRecord()]
+        if (metadataService.getBasisOfRecord() && metadataService.getBasisOfRecord().facets)
+            render view: 'panels/basisRecordsPanel', model: [basisOfRecord: metadataService.getBasisOfRecord()]
+        else
+            render view: 'panels/empty'
     }
 
     def dateRecordsPanel = {
-        render view: 'panels/dateRecordsPanel', model: [dateStats: metadataService.getDateStats()]
+        if (metadataService.getDateStats())
+            render view: 'panels/dateRecordsPanel', model: [dateStats: metadataService.getDateStats()]
+        else
+            render view: 'panels/empty'
     }
 
     def nslPanel = {
-        render view: 'panels/nslPanel', model: [taxaCounts: metadataService.getTaxaCounts()]
+        if (metadataService.getTaxaCounts())
+            render view: 'panels/nslPanel', model: [taxaCounts: metadataService.getTaxaCounts()]
+        else
+            render view: 'panels/empty'
     }
 
     def spatialPanel = {
-        render view: 'panels/spatialPanel', model: [spatialLayers: metadataService.getSpatialLayers()]
+        if (metadataService.getSpatialLayers() && metadataService.getSpatialLayers().groups)
+            render view: 'panels/spatialPanel', model: [spatialLayers: metadataService.getSpatialLayers()]
+        else
+            render view: 'panels/empty'
     }
 
     def statePanel = {
@@ -62,43 +83,74 @@ class DashboardController {
     }
 
     def identifyLifePanel = {
-        render view: 'panels/identifyLifePanel', model: [identifyLifeCounts: metadataService.getIdentifyLifeCounts()]
+        if (metadataService.getIdentifyLifeCounts())
+            render view: 'panels/identifyLifePanel', model: [identifyLifeCounts: metadataService.getIdentifyLifeCounts()]
+        else
+            render view: 'panels/empty'
     }
 
     def mostRecordedSpeciesPanel = {
-        render view: 'panels/mostRecordedSpeciesPanel', model: [mostRecorded: metadataService.getMostRecordedSpecies('all')]
+        if (metadataService.getMostRecordedSpecies())
+            render view: 'panels/mostRecordedSpeciesPanel', model: [mostRecorded: metadataService.getMostRecordedSpecies('all')]
+        else
+            render view: 'panels/empty'
     }
 
     def typeSpecimensPanel = {
-        render view: 'panels/typeSpecimensPanel', model: [typeCounts: metadataService.getTypeStats()]
+        if (metadataService.getTypeStats())
+            render view: 'panels/typeSpecimensPanel', model: [typeCounts: metadataService.getTypeStats()]
+        else
+            render view: 'panels/empty'
     }
 
     def barcodeOfLifePanel = {
-        render view: 'panels/barcodeOfLifePanel', model: [boldCounts: metadataService.getBoldCounts()]
+        if (metadataService.getBoldCounts())
+            render view: 'panels/barcodeOfLifePanel', model: [boldCounts: metadataService.getBoldCounts()]
+        else
+            render view: 'panels/empty'
     }
 
     def bhlPanel = {
-        render view: 'panels/bhlPanel', model: [bhlCounts: metadataService.getBHLCounts()]
+        if (metadataService.getBHLCounts())
+            render view: 'panels/bhlPanel', model: [bhlCounts: metadataService.getBHLCounts()]
+        else
+            render view: 'panels/empty'
     }
 
     def volunteerPortalPanel = {
-        render view: 'panels/volunteerPortalPanel', model: [volunteerPortalCounts: metadataService.getVolunteerStats()]
+        if (grailsApplication.config.getProperty("useVolunteerService", Boolean, true) &&
+                metadataService.getVolunteerStats())
+            render view: 'panels/volunteerPortalPanel', model: [volunteerPortalCounts: metadataService.getVolunteerStats()]
+        else
+            render view: 'panels/empty'
     }
 
     def conservationStatusPanel = {
-        render view: 'panels/conservationStatusPanel', model: [stateConservation: metadataService.getSpeciesByConservationStatus()]
+        if (metadataService.getSpeciesByConservationStatus())
+            render view: 'panels/conservationStatusPanel', model: [stateConservation: metadataService.getSpeciesByConservationStatus()]
+        else
+            render view: 'panels/empty'
     }
 
     def recordsByDataProviderPanel = {
-        render view: 'panels/recordsByDataProviderPanel', model: [dataProviders: metadataService.getDataProviders()]
+        if (metadataService.getDataProviders())
+            render view: 'panels/recordsByDataProviderPanel', model: [dataProviders: metadataService.getDataProviders()]
+        else
+            render view: 'panels/empty'
     }
 
     def recordsByInstitutionPanel = {
-        render view: 'panels/recordsByInstitutionPanel', model: [institutions: metadataService.getInstitutions()]
+        if (metadataService.getInstitutions())
+            render view: 'panels/recordsByInstitutionPanel', model: [institutions: metadataService.getInstitutions()]
+        else
+            render view: 'panels/empty'
     }
 
     def recordsByLifeFormPanel = {
-        render view: 'panels/recordsByLifeFormPanel', model: [records: metadataService.getRecordsByLifeForm()]
+        if (metadataService.getRecordsByLifeForm())
+            render view: 'panels/recordsByLifeFormPanel', model: [records: metadataService.getRecordsByLifeForm()]
+        else
+            render view: 'panels/empty'
     }
 
     def recordsAndSpeciesByDecadePanel = {
@@ -110,23 +162,38 @@ class DashboardController {
     }
 
     def usageStatisticsPanel = {
-        render view: 'panels/usageStatisticsPanel', model: [loggerTotals: metadataService.getLoggerTotals()]
+        if (metadataService.getLoggerTotals())
+            render view: 'panels/usageStatisticsPanel', model: [loggerTotals: metadataService.getLoggerTotals()]
+        else
+            render view: 'panels/empty'
     }
 
     def downloadsByReasonPanel = {
-        render view: 'panels/downloadsByReasonPanel', model: [loggerReasonBreakdown: metadataService.getLoggerReasonBreakdown()]
+        if (metadataService.getLoggerReasonBreakdown())
+            render view: 'panels/downloadsByReasonPanel', model: [loggerReasonBreakdown: metadataService.getLoggerReasonBreakdown()]
+        else
+            render view: 'panels/empty'
     }
 
     def downloadsBySourcePanel = {
-        render view: 'panels/downloadsBySourcePanel', model: [loggerSourceBreakdown: metadataService.getLoggerSourceBreakdown()]
+        if (metadataService.getLoggerSourceBreakdown())
+            render view: 'panels/downloadsBySourcePanel', model: [loggerSourceBreakdown: metadataService.getLoggerSourceBreakdown()]
+        else
+            render view: 'panels/empty'
     }
 
     def downloadsByUserTypePanel = {
-        render view: 'panels/downloadsByUserTypePanel', model: [loggerEmailBreakdown: metadataService.getLoggerEmailBreakdown()]
+        if (metadataService.getLoggerEmailBreakdown())
+            render view: 'panels/downloadsByUserTypePanel', model: [loggerEmailBreakdown: metadataService.getLoggerEmailBreakdown()]
+        else
+            render view: 'panels/empty'
     }
 
     def speciesImagesPanel = {
-        render view: 'panels/speciesImagesPanel', model: [imagesBreakdown: metadataService.getImagesBreakdown()]
+        if (metadataService.getImagesBreakdown())
+            render view: 'panels/speciesImagesPanel', model: [imagesBreakdown: metadataService.getImagesBreakdown()]
+        else
+            render view: 'panels/empty'
     }
 
     def mostRecorded(String group) {

--- a/grails-app/controllers/au/org/ala/dashboard/DashboardController.groovy
+++ b/grails-app/controllers/au/org/ala/dashboard/DashboardController.groovy
@@ -113,7 +113,8 @@ class DashboardController {
     }
 
     def bhlPanel = {
-        if (metadataService.getBHLCounts())
+        if (grailsApplication.config.getProperty("useBHLService", Boolean, true) &&
+                metadataService.getBHLCounts())
             render view: 'panels/bhlPanel', model: [bhlCounts: metadataService.getBHLCounts()]
         else
             render view: 'panels/empty'

--- a/grails-app/controllers/au/org/ala/dashboard/DashboardController.groovy
+++ b/grails-app/controllers/au/org/ala/dashboard/DashboardController.groovy
@@ -65,7 +65,8 @@ class DashboardController {
     }
 
     def nslPanel = {
-        if (metadataService.getTaxaCounts())
+        if (grailsApplication.config.getProperty("useNationalSpeciesListsService", Boolean, true) &&
+                metadataService.getTaxaCounts())
             render view: 'panels/nslPanel', model: [taxaCounts: metadataService.getTaxaCounts()]
         else
             render view: 'panels/empty'
@@ -104,7 +105,8 @@ class DashboardController {
     }
 
     def barcodeOfLifePanel = {
-        if (metadataService.getBoldCounts())
+        if (grailsApplication.config.getProperty("useBarcodeOfLifeService", Boolean, true) &&
+                metadataService.getBoldCounts())
             render view: 'panels/barcodeOfLifePanel', model: [boldCounts: metadataService.getBoldCounts()]
         else
             render view: 'panels/empty'

--- a/grails-app/controllers/au/org/ala/dashboard/DashboardController.groovy
+++ b/grails-app/controllers/au/org/ala/dashboard/DashboardController.groovy
@@ -90,7 +90,7 @@ class DashboardController {
     }
 
     def mostRecordedSpeciesPanel = {
-        if (metadataService.getMostRecordedSpecies())
+        if (metadataService.getMostRecordedSpecies('all'))
             render view: 'panels/mostRecordedSpeciesPanel', model: [mostRecorded: metadataService.getMostRecordedSpecies('all')]
         else
             render view: 'panels/empty'

--- a/grails-app/views/dashboard/panels/empty.gsp
+++ b/grails-app/views/dashboard/panels/empty.gsp
@@ -1,0 +1,2 @@
+<div class="col-sm-4 col-md-4">
+</div>

--- a/grails-app/views/dashboard/panels/empty.gsp
+++ b/grails-app/views/dashboard/panels/empty.gsp
@@ -1,2 +1,0 @@
-<div class="col-sm-4 col-md-4">
-</div>

--- a/grails-app/views/dashboard/panels/speciesImagesPanel.gsp
+++ b/grails-app/views/dashboard/panels/speciesImagesPanel.gsp
@@ -14,10 +14,14 @@
                         <tr><td>Taxa with images</td><td class="numberColumn">${g.formatNumber(number: imagesBreakdown["taxaWithImages"], type: 'number')}</td></tr>
                         <tr><td>Species with images</td><td class="numberColumn">${g.formatNumber(number: imagesBreakdown["speciesWithImages"], type: 'number')}</td></tr>
                         <tr><td>Subspecies with images</td><td class="numberColumn">${g.formatNumber(number: imagesBreakdown["subspeciesWithImages"], type: 'number')}</td></tr>
-                        <tr><td>Taxa with images from<br/> DigiVol
-                        </td><td class="numberColumn">${g.formatNumber(number: imagesBreakdown["taxaWithImagesFromVolunteerPortal"], type: 'number')}</td></tr>
-                        <tr><td>Taxa with images from<br/> citizen science
-                        </td><td class="numberColumn">${g.formatNumber(number: imagesBreakdown["taxaWithImagesFromCS"], type: 'number')}</td></tr>
+                        <g:if test="${grailsApplication.config.getProperty("useVolunteerService", Boolean, true)}">
+                            <tr><td>Taxa with images from<br/> DigiVol
+                            </td><td class="numberColumn">${g.formatNumber(number: imagesBreakdown["taxaWithImagesFromVolunteerPortal"], type: 'number')}</td></tr>
+                        </g:if>
+                        <g:if test="${grailsApplication.config.getProperty("useCitizenScienceService", Boolean, true)}">
+                            <tr><td>Taxa with images from<br/> citizen science
+                            </td><td class="numberColumn">${g.formatNumber(number: imagesBreakdown["taxaWithImagesFromCS"], type: 'number')}</td></tr>
+                        </g:if>
                     </tbody>
                     <tfoot>
                         <tr class="total-highlight"><td>Total number of images</td><td class="numberColumn">${g.formatNumber(number: imagesBreakdown["imageTotal"], type: 'number')}</td></tr>


### PR DESCRIPTION
Currently the dashboard only works when all queries returns values and all the ALA services are working as expected. This PR:
- Addresses partially #96 making some services optional 
- It also addresses partially #85. This is also interesting in the LA community as it will allow to run the LA dashboard in new LA portals without data or LA portals without some services (like BIE, or spatial).

I've tested with:
- ALA services (double checking that I don't break nothing with this PR in the ALA production dashboard, attached my properties).
- An empty LA new deployment
- And now that I can generate inventories and `/data` directories easily, I also tested with Canadensys, Sweden and Vermont portals.

[ALA-dashboard-config.properties.txt](https://github.com/AtlasOfLivingAustralia/dashboard/files/5712261/dashboard-config.properties.txt)






