### PR TITLE
Fix hardcoded links in Spatial and Typespecimens panels

### DIFF
--- a/grails-app/views/dashboard/panels/spatialPanel.gsp
+++ b/grails-app/views/dashboard/panels/spatialPanel.gsp
@@ -2,7 +2,7 @@
     <div class="panel">
         <div class="panel-heading">
             <div class="panel-title">
-                <a href="https://spatial.ala.org.au/layers"><span class="count">${spatialLayers.total}</span>
+                <a href="${grailsApplication.config.spatial.baseURL}/layers/index"><span class="count">${spatialLayers.total}</span>
                 </a> Spatial layers
                 <i class="fa fa-info-circle pull-right hidden"></i>
             </div>

--- a/grails-app/views/dashboard/panels/typeSpecimensPanel.gsp
+++ b/grails-app/views/dashboard/panels/typeSpecimensPanel.gsp
@@ -2,7 +2,7 @@
     <div class="panel">
         <div class="panel-heading">
             <div class="panel-title">
-                <a href="https://biocache.ala.org.au/occurrences/search?q=type_status:[*%20TO%20*]&fq=-type_status:notatype">
+                <a href="${grailsApplication.config.biocache.webappURL}/occurrences/search?q=type_status:[*%20TO%20*]&fq=-type_status:notatype">
                     <span class="count"><db:formatNumber value="${typeCounts.total}"/></span>
                 </a>
                 Type specimens


### PR DESCRIPTION
Use values from config instead of linking to ala.au.org.