### PR TITLE
Fix styling issue in "Most recorded species" panel

### DIFF
--- a/grails-app/assets/javascripts/dashboard.js
+++ b/grails-app/assets/javascripts/dashboard.js
@@ -186,11 +186,11 @@ var dashboard = {
                     } else {
                         $.each(data.facets, function(i, obj) {
                             html += "<tr><td id='"+ obj.facet + "'><em>" + obj.name + "</em>" +
-                            (obj.common === null ? "" : (" - " + obj.common)) + "</td><td>" +
+                            (obj.common === null ? "" : (" - " + obj.common)) + "</td><td class='numberColumn'>" +
                             "<span class='count'>" + obj.count + "</span></td></tr>";
                         });
                     }
-                    $('#mostRecorded table').html(html);
+                    $('#mostRecorded table').html('<tbody>' + html + '</tbody>');
                     jQuery.fn.matchHeight._update(); // adjust heights
                 }
             });

--- a/grails-app/views/dashboard/panels/mostRecordedSpeciesPanel.gsp
+++ b/grails-app/views/dashboard/panels/mostRecordedSpeciesPanel.gsp
@@ -13,7 +13,7 @@
                     <g:each in="${mostRecorded.facets}" var="m">
                         <tr class="link"><td id="${m.facet}"><em>${m.name}</em>
                             <g:if test="${m.common}">- ${m.common}</g:if></td>
-                            <td><span class="count">${m.formattedCount}</span></td>
+                            <td class="numberColumn"><span class="count">${m.formattedCount}</span></td>
                         </tr>
                     </g:each>
                 </table>


### PR DESCRIPTION
The intended styling applied in backend (striped tables, right-aligned numbers) is lost when the content is re-generated in frontend.