### PR TITLE
Url encode square brackets

### DIFF
--- a/grails-app/assets/javascripts/dashboard.js
+++ b/grails-app/assets/javascripts/dashboard.js
@@ -294,7 +294,7 @@ var dashboard = {
                 // treat as first year of a century
                 var startYear = Number(id),
                     endYear = startYear + 99,
-                    range = "[" + startYear + "-01-01T00:00:00Z+TO+" + endYear + "-12-31T23:59:59Z]";
+                    range = "%5B" + startYear + "-01-01T00:00:00Z+TO+" + endYear + "-12-31T23:59:59Z%5D";
                 document.location.href = dashboard.urls.biocacheUI + "/occurrences/search?q=*:*&fq=occurrence_year:" + range;
             }
         });

--- a/grails-app/services/au/org/ala/dashboard/MetadataService.groovy
+++ b/grails-app/services/au/org/ala/dashboard/MetadataService.groovy
@@ -159,7 +159,7 @@ class MetadataService {
 
             // get counts by century
             [1600, 1700, 1800, 1900, 2000].each { century ->
-                def url = "${BIO_CACHE_URL}/occurrences/search?q=*:*&pageSize=0&facet=off&fq=occurrence_year:[${century}-01-01T00:00:00Z%20TO%20${century + 99}-12-31T23:59:59Z]"
+                def url = "${BIO_CACHE_URL}/occurrences/search?q=*:*&pageSize=0&facet=off&fq=occurrence_year:%5B${century}-01-01T00:00:00Z%20TO%20${century + 99}-12-31T23:59:59Z%5D"
                 def c = webService.getJson(url)
                 results['c' + century] = c.totalRecords
             }
@@ -178,7 +178,7 @@ class MetadataService {
             def results = [:]
 
             // type counts
-            def facets = biocacheFacetCount('type_status', 'type_status:[*%20TO%20*]')
+            def facets = biocacheFacetCount('type_status', 'type_status:%5B*%20TO%20*%5D')
             facets.facets.each {
                 if (it.facet != 'notatype') {
                     results[it.facet] = it.count
@@ -220,7 +220,7 @@ class MetadataService {
                     decade = it.toString() + '0s'
                 }
                 def to = (it.toString() + '9-12-31T23:59:59Z')
-                def url = baseUrl + '[' + from + '+TO+' + to + ']'
+                def url = baseUrl + '%5B' + from + '+TO+' + to + '%5D'
                 def json = new URL(url).text
                 def result = JSON.parse(json)
                 def totals = result.find { it.name == 'ALL_SPECIES' }

--- a/grails-app/views/dashboard/panels/typeSpecimensPanel.gsp
+++ b/grails-app/views/dashboard/panels/typeSpecimensPanel.gsp
@@ -2,7 +2,7 @@
     <div class="panel">
         <div class="panel-heading">
             <div class="panel-title">
-                <a href="https://biocache.ala.org.au/occurrences/search?q=type_status:[*%20TO%20*]&fq=-type_status:notatype">
+                <a href="https://biocache.ala.org.au/occurrences/search?q=type_status:%5B*%20TO%20*%5D&fq=-type_status:notatype">
                     <span class="count"><db:formatNumber value="${typeCounts.total}"/></span>
                 </a>
                 Type specimens


### PR DESCRIPTION
Even though it mostly works without encoding them it's safer to do so than to rely on forgiving server implementations (it doesn't actually work with unencoded brackets on our installation).